### PR TITLE
fix: Explicitly define job permissions

### DIFF
--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -16,6 +16,11 @@ env:
 # Defined CI jobs.
 jobs:
   check:
+    # This is set explictly to allow Meow-Coverage to post comments in response to Dependabot PRs which have a read-only GITHUB_TOKEN by default
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
     runs-on: ${{ inputs.runs-on }}
     container: ghcr.io/famedly/rust-container:nightly
     steps:


### PR DESCRIPTION
This explicitly defines the permissions the job has, in order to allow meow-coverage to work on Dependabot PRs which otherwise have a read-only GITHUB_TOKEN.

Closes #17 