### PR TITLE
ci: Change to ubuntu 16 cores

### DIFF
--- a/.github/workflows/docker-backend.yml
+++ b/.github/workflows/docker-backend.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16core
     steps:
       - uses: actions/checkout@v4
 
@@ -39,10 +39,10 @@ jobs:
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
-            mkdir -p ~/.ssh
-            ssh-keyscan github.com >> ~/.ssh/known_hosts
-            ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-            ssh-add - <<< "${{ secrets.CI_SSH_PRIVATE_KEY }}" || true
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-add - <<< "${{ secrets.CI_SSH_PRIVATE_KEY }}" || true
 
       - name: Build container
         shell: bash


### PR DESCRIPTION
We need to go back to ubuntu 16 cores because the build of the docker image is failing on the backend system test. See issue #36 