### PR TITLE
chore: Update rust-cache action to v2.8.0

### DIFF
--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Caching
-      uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
+      uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
 
     - name: Rustfmt
       shell: bash
@@ -106,7 +106,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Caching
-      uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
+      uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
 
     - name: Test
       shell: bash


### PR DESCRIPTION
Closes #59 