### PR TITLE
fix: Use releases registry in Harbor

### DIFF
--- a/.github/workflows/docker-backend.yml
+++ b/.github/workflows/docker-backend.yml
@@ -33,7 +33,7 @@ on:
 env:
   RUSTC_WRAPPER: cachepot
   REGISTRY_SNAPSHOTS: registry.famedly.net/nightly
-  REGISTRY_RELEASES: registry.famedly.net/docker
+  REGISTRY_RELEASES: registry.famedly.net/docker-releases
   REGISTRY_OSS: registry.famedly.net/docker-oss
 
 jobs:


### PR DESCRIPTION
Part of https://github.com/famedly/team-workflows/issues/73