### PR TITLE
fix: Remove the v4 from rust-prepare in the test job

### DIFF
--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -93,7 +93,7 @@ jobs:
         repository: famedly/backend-build-workflows
         ref: ${{ inputs.ref }}
 
-    - uses: ./.github/actions/rust-prepare@v4
+    - uses: ./.github/actions/rust-prepare
       with:
         crate_registry_ssh_privkey: ${{ secrets.CRATE_REGISTRY_SSH_PRIVKEY}}
 


### PR DESCRIPTION
Since we are calling a file directly the `@v4` is interpreted as part of the path and not a git ref. This breaks the pipeline